### PR TITLE
fix: allow exact Chrome Web Store release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
           - patch
           - minor
           - major
+      target_version:
+        description: 'Optional exact version override (for example, 1.2.1). If set, version_type is ignored.'
+        required: false
+        type: string
 
 jobs:
   release:
@@ -36,8 +40,15 @@ jobs:
 
       - name: Bump version
         id: bump
+        env:
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          TARGET_VERSION: ${{ github.event.inputs.target_version }}
         run: |
-          node scripts/bump-version.js ${{ github.event.inputs.version_type }} > bump_output.txt
+          if [ -n "$TARGET_VERSION" ]; then
+            node scripts/bump-version.js "$TARGET_VERSION" > bump_output.txt
+          else
+            node scripts/bump-version.js "$VERSION_TYPE" > bump_output.txt
+          fi
           cat bump_output.txt
           NEW_VERSION=$(grep "NEW_VERSION=" bump_output.txt | cut -d'=' -f2)
           OLD_VERSION=$(grep "OLD_VERSION=" bump_output.txt | cut -d'=' -f2)
@@ -67,7 +78,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add manifest.template.json package.json
+          git add manifest.template.json package.json package-lock.json
           git commit -m "chore: release version ${{ steps.bump.outputs.new_version }}"
           git tag -a "v${{ steps.bump.outputs.new_version }}" -m "Release version ${{ steps.bump.outputs.new_version }}"
           git push origin main

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -8,11 +8,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
 
-// Get version type from command line args (patch, minor, major)
-const versionType = process.argv[2] || 'patch';
+// Get version type or exact target version from command line args.
+// Supported values: patch, minor, major, or an exact Chrome extension version
+// such as 1.2.1.
+const versionInput = process.argv[2] || 'patch';
 
-if (!['patch', 'minor', 'major'].includes(versionType)) {
-  console.error('Usage: node bump-version.js [patch|minor|major]');
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+if (!['patch', 'minor', 'major'].includes(versionInput) && !VERSION_PATTERN.test(versionInput)) {
+  console.error('Usage: node bump-version.js [patch|minor|major|x.y.z]');
   process.exit(1);
 }
 
@@ -37,19 +41,57 @@ function bumpVersion(version, type) {
   return parts.join('.');
 }
 
+function compareVersions(a, b) {
+  const aParts = a.split('.').map(Number);
+  const bParts = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i++) {
+    if (aParts[i] !== bParts[i]) {
+      return aParts[i] - bParts[i];
+    }
+  }
+
+  return 0;
+}
+
+function writeJson(path, data) {
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+}
+
 // Update manifest.template.json
 const manifestPath = join(rootDir, 'manifest.template.json');
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
 const oldVersion = manifest.version;
-const newVersion = bumpVersion(oldVersion, versionType);
+const newVersion = VERSION_PATTERN.test(versionInput) ? versionInput : bumpVersion(oldVersion, versionInput);
+
+if (compareVersions(newVersion, oldVersion) <= 0) {
+  console.error(`Error: new version (${newVersion}) must be greater than current version (${oldVersion})`);
+  process.exit(1);
+}
+
 manifest.version = newVersion;
-writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+writeJson(manifestPath, manifest);
 
 // Update package.json
 const packagePath = join(rootDir, 'package.json');
 const packageJson = JSON.parse(readFileSync(packagePath, 'utf-8'));
 packageJson.version = newVersion;
-writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n');
+writeJson(packagePath, packageJson);
+
+// Update package-lock.json if present so release commits keep npm metadata in sync.
+const packageLockPath = join(rootDir, 'package-lock.json');
+try {
+  const packageLockJson = JSON.parse(readFileSync(packageLockPath, 'utf-8'));
+  packageLockJson.version = newVersion;
+  if (packageLockJson.packages?.['']) {
+    packageLockJson.packages[''].version = newVersion;
+  }
+  writeJson(packageLockPath, packageLockJson);
+} catch (error) {
+  if (error.code !== 'ENOENT') {
+    throw error;
+  }
+}
 
 console.log(`Version bumped from ${oldVersion} to ${newVersion}`);
 console.log(`NEW_VERSION=${newVersion}`);


### PR DESCRIPTION
## Summary

This PR fixes the Chrome Web Store release workflow when the repository version is behind the already-published store version.

The Chrome Web Store currently has `1.2.0`, but `main` still has `1.1.4`. The existing workflow could only bump from the repository version:

- `patch` -> `1.1.5`, still lower than Chrome Web Store
- `minor` -> `1.2.0`, equal to Chrome Web Store and not uploadable
- `major` -> `2.0.0`, too large for this release

## Changes

- Add optional `target_version` workflow input for exact release versions, e.g. `1.2.1`.
- Keep existing `patch` / `minor` / `major` behavior when `target_version` is empty.
- Allow `scripts/bump-version.js` to accept either a bump type or an exact `x.y.z` version.
- Reject non-incrementing target versions relative to the repository version.
- Sync version metadata across:
  - `manifest.template.json`
  - `package.json`
  - `package-lock.json`

## Release Instructions

After this PR is merged, run **Release to Chrome Web Store** manually with:

- `version_type`: `patch` (ignored when `target_version` is set)
- `target_version`: `1.2.1`

This will generate and upload extension version `1.2.1` without requiring an incorrect major bump.

## Verification

- Tested exact bump to `1.2.1` in a temporary directory
- Tested subsequent `patch` bump still works
- Tested non-incrementing target versions are rejected
- `npm run lint`
- `npx tsc --noEmit`
- `OAUTH_CLIENT_ID=test-client-id EXTENSION_KEY=test-extension-key npm run generate-manifest && npm run build`
- GitHub CI passes
