### PR TITLE
fix: stabilize selection capture target tab

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -183,8 +183,8 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
  * Handle screenshot capture from message
  */
 async function handleScreenshotCaptureMessage(message: CaptureScreenshotMessage) {
-  const { mode, options = {}, fromPopup } = message.payload;
-  return await handleScreenshotCapture(mode, { ...options, fromPopup });
+  const { mode, options = {}, fromPopup, target } = message.payload;
+  return await handleScreenshotCapture(mode, { ...options, fromPopup, target });
 }
 
 // Store pending selection resolve/reject callbacks
@@ -499,8 +499,12 @@ async function handleScreenshotCapture(
 ) {
   const fromPopup = options?.fromPopup === true;
   try {
-    // Get current active tab first
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    // Prefer the tab captured by the popup click handler. In a service worker,
+    // currentWindow can be ambiguous once focus has moved to the extension popup.
+    const tab = options?.target?.tabId
+      ? await chrome.tabs.get(options.target.tabId)
+      : (await chrome.tabs.query({ active: true, lastFocusedWindow: true }))[0];
+
     if (!tab.id || !tab.windowId) {
       throw new Error('No active tab found');
     }

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -227,7 +227,7 @@ function rejectPendingSelection(error: unknown): void {
  * Handle selection mode capture
  * Injects content script and waits for user selection
  */
-async function handleSelectionCapture(tab: chrome.tabs.Tab): Promise<any> {
+async function handleSelectionCapture(tab: chrome.tabs.Tab, fromPopup: boolean): Promise<any> {
   if (!tab.id || !tab.windowId) {
     throw new Error('No active tab found');
   }
@@ -241,6 +241,8 @@ async function handleSelectionCapture(tab: chrome.tabs.Tab): Promise<any> {
   if (pendingSelectionReject) {
     rejectPendingSelection(new Error('Selection cancelled: a new selection was started'));
   }
+
+  pendingSelectionFromPopup = fromPopup;
 
   // Inject the selection overlay content script
   try {
@@ -533,9 +535,8 @@ async function handleScreenshotCapture(
 
     // Handle selection mode - inject content script and wait for selection
     if (mode === 'selection') {
-      pendingSelectionFromPopup = fromPopup;
       try {
-        return await handleSelectionCapture(tab);
+        return await handleSelectionCapture(tab, fromPopup);
       } catch (error) {
         resetPendingSelectionState();
         throw error;

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -188,10 +188,17 @@ async function handleScreenshotCaptureMessage(message: CaptureScreenshotMessage)
 }
 
 // Store pending selection resolve/reject callbacks
+type PendingSelectionTarget = {
+  tabId: number;
+  windowId: number;
+  url?: string;
+};
+
 let pendingSelectionResolve: ((value: any) => void) | null = null;
 let pendingSelectionReject: ((reason: any) => void) | null = null;
 let pendingSelectionFromPopup = false;
 let pendingSelectionTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let pendingSelectionTarget: PendingSelectionTarget | null = null;
 
 function clearPendingSelectionTimeout(): void {
   if (pendingSelectionTimeoutId !== null) {
@@ -200,14 +207,20 @@ function clearPendingSelectionTimeout(): void {
   }
 }
 
+function resetPendingSelectionState(): void {
+  pendingSelectionResolve = null;
+  pendingSelectionReject = null;
+  pendingSelectionFromPopup = false;
+  pendingSelectionTarget = null;
+}
+
 function rejectPendingSelection(error: unknown): void {
-  if (pendingSelectionReject) {
-    clearPendingSelectionTimeout();
-    pendingSelectionReject(error);
-    pendingSelectionResolve = null;
-    pendingSelectionReject = null;
-    pendingSelectionFromPopup = false;
+  const reject = pendingSelectionReject;
+  clearPendingSelectionTimeout();
+  if (reject) {
+    reject(error);
   }
+  resetPendingSelectionState();
 }
 
 /**
@@ -215,7 +228,7 @@ function rejectPendingSelection(error: unknown): void {
  * Injects content script and waits for user selection
  */
 async function handleSelectionCapture(tab: chrome.tabs.Tab): Promise<any> {
-  if (!tab.id) {
+  if (!tab.id || !tab.windowId) {
     throw new Error('No active tab found');
   }
 
@@ -240,10 +253,17 @@ async function handleSelectionCapture(tab: chrome.tabs.Tab): Promise<any> {
     throw new Error('Failed to start selection mode. Make sure you are on a valid web page.');
   }
 
+  const selectionTarget: PendingSelectionTarget = {
+    tabId: tab.id,
+    windowId: tab.windowId,
+    url: tab.url,
+  };
+
   // Wait for selection to complete via message
   return new Promise((resolve, reject) => {
     pendingSelectionResolve = resolve;
     pendingSelectionReject = reject;
+    pendingSelectionTarget = selectionTarget;
 
     // Timeout after 60 seconds
     pendingSelectionTimeoutId = setTimeout(() => {
@@ -293,12 +313,11 @@ async function handleSelectionComplete(payload: unknown) {
     const reason = typeof p.reason === 'string' ? p.reason : undefined;
     logger.log('Selection cancelled:', reason);
     clearPendingSelectionTimeout();
-    if (pendingSelectionResolve) {
-      pendingSelectionResolve({ cancelled: true, reason });
-      pendingSelectionResolve = null;
-      pendingSelectionReject = null;
-      pendingSelectionFromPopup = false;
+    const resolve = pendingSelectionResolve;
+    if (resolve) {
+      resolve({ cancelled: true, reason });
     }
+    resetPendingSelectionState();
     return;
   }
 
@@ -309,8 +328,10 @@ async function handleSelectionComplete(payload: unknown) {
   logger.log('Selection complete:', coordinates);
 
   try {
-    // Get the active tab to capture
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    // Capture the same tab/window where the selection overlay was injected.
+    const tab = pendingSelectionTarget
+      ? await chrome.tabs.get(pendingSelectionTarget.tabId)
+      : (await chrome.tabs.query({ active: true, lastFocusedWindow: true }))[0];
     if (!tab.id || !tab.windowId) {
       throw new Error('No active tab found');
     }
@@ -408,13 +429,15 @@ async function handleSelectionComplete(payload: unknown) {
 
     await assetStorage.setAsset(asset);
 
+    const shouldAutoUpload = settings.autoUpload && !pendingSelectionFromPopup;
+
     // Show notification
-    await showCaptureNotification(settings.autoUpload && !pendingSelectionFromPopup);
+    await showCaptureNotification(shouldAutoUpload);
     await updateExtensionBadge();
 
     // Auto-upload if enabled and not initiated from popup
     // (popup handles upload after showing headline/caption modal)
-    if (settings.autoUpload && !pendingSelectionFromPopup) {
+    if (shouldAutoUpload) {
       try {
         const numbersApi = await getNumbersApi();
         let auth = numbersApi.auth.isAuthenticated();
@@ -453,17 +476,16 @@ async function handleSelectionComplete(payload: unknown) {
       clearTimeout(pendingSelectionTimeoutId);
       pendingSelectionTimeoutId = null;
     }
-    if (pendingSelectionResolve) {
-      pendingSelectionResolve({
+    const resolve = pendingSelectionResolve;
+    if (resolve) {
+      resolve({
         assetId,
         dataUrl,
         timestamp: captureTime.toISOString(),
-        autoUpload: settings.autoUpload && !pendingSelectionFromPopup,
+        autoUpload: shouldAutoUpload,
       });
-      pendingSelectionResolve = null;
-      pendingSelectionReject = null;
-      pendingSelectionFromPopup = false;
     }
+    resetPendingSelectionState();
   } catch (error: any) {
     logger.error('Failed to capture selection:', error);
     rejectPendingSelection(error);
@@ -512,7 +534,12 @@ async function handleScreenshotCapture(
     // Handle selection mode - inject content script and wait for selection
     if (mode === 'selection') {
       pendingSelectionFromPopup = fromPopup;
-      return await handleSelectionCapture(tab);
+      try {
+        return await handleSelectionCapture(tab);
+      } catch (error) {
+        resetPendingSelectionState();
+        throw error;
+      }
     }
 
     // Capture timestamp at the very start for consistency

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -102,11 +102,21 @@ function PopupApp() {
   async function handleCapture(mode: 'visible' | 'selection' = captureMode) {
     setCapturing(true);
     try {
+      const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+      if (!tab?.id || !tab.windowId) {
+        throw new Error('No active tab found');
+      }
+
       const response = await chrome.runtime.sendMessage({
         type: 'CAPTURE_SCREENSHOT',
         payload: {
           mode: mode,
           fromPopup: true, // Skip auto-upload so user can add headline/caption first
+          target: {
+            tabId: tab.id,
+            windowId: tab.windowId,
+            url: tab.url,
+          },
         },
       });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,5 +60,10 @@ export interface CaptureScreenshotMessage {
     mode: CaptureMode;
     options?: Partial<ScreenshotOptions>;
     fromPopup?: boolean; // When true, skip auto-upload to allow adding metadata first
+    target?: {
+      tabId: number;
+      windowId: number;
+      url?: string;
+    };
   };
 }


### PR DESCRIPTION
## Summary
- Capture the popup-selected tab/window when the user starts a screenshot capture
- Pass the explicit target tab to the background service worker instead of re-resolving `currentWindow`
- Preserve the pending selection target through overlay injection and selection completion
- Preserve popup/non-popup state when replacing an existing pending selection

## Why
Selection mode could fail with `Failed to start selection mode. Make sure you are on a valid web page.` because the service worker re-resolved the active tab after focus moved to the extension popup. The popup now sends the intended target tab explicitly, and the background keeps that same target through the selection completion flow.

This also avoids a follow-up regression where replacing an existing pending selection could reset the new capture's `fromPopup` state.

## Asset edit modal and auto-upload behavior
- Popup-initiated captures send `fromPopup: true`
- Popup captures are saved as drafts and open the asset edit modal for headline/caption
- `Register to Numbers` saves metadata first, then queues upload via `UPLOAD_ASSET`
- Non-popup captures still respect `settings.autoUpload && !fromPopup`, so auto-upload after capture remains intact

## Verification
- `npm run lint` (0 errors; existing warnings only)
- `npx tsc --noEmit`
- `npm run build`
- GitHub CI passes
