### PR TITLE
[Omni] Fix popup Snap watermark response handling

### DIFF
--- a/.omni/e42f8a19-untitled/memory.md
+++ b/.omni/e42f8a19-untitled/memory.md
@@ -18,7 +18,7 @@
 ## Key Discoveries
 
 - Selection capture is coordinated in `src/background/service-worker.ts`: popup sends `CAPTURE_SCREENSHOT`, service worker injects the selection overlay, then receives `SELECTION_COMPLETE` and crops via the offscreen document.
-- Selection overlay injection should guard `chrome.scripting` availability; fallback can use legacy `chrome.tabs.executeScript` before surfacing an explicit reload/permission error.
+- Popup runtime message listeners must ignore unrelated messages synchronously; an async listener can interfere with offscreen `ADD_WATERMARK` responses while the popup is open.
 
 ---
-_Last system refresh: 2026-05-06 06:48 UTC_
+_Last system refresh: 2026-05-06 07:09 UTC_

--- a/.omni/e42f8a19-untitled/memory.md
+++ b/.omni/e42f8a19-untitled/memory.md
@@ -18,6 +18,7 @@
 ## Key Discoveries
 
 - Selection capture is coordinated in `src/background/service-worker.ts`: popup sends `CAPTURE_SCREENSHOT`, service worker injects the selection overlay, then receives `SELECTION_COMPLETE` and crops via the offscreen document.
+- Selection overlay injection should guard `chrome.scripting` availability; fallback can use legacy `chrome.tabs.executeScript` before surfacing an explicit reload/permission error.
 
 ---
-_Last system refresh: 2026-05-06 06:33 UTC_
+_Last system refresh: 2026-05-06 06:48 UTC_

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -421,38 +421,6 @@ function startProofSnapSelectionOverlay(): void {
   }
 }
 
-function getSelectionOverlayInjectionCode(): string {
-  return `(${startProofSnapSelectionOverlay.toString()})();`;
-}
-
-async function injectSelectionOverlay(tabId: number): Promise<void> {
-  if (chrome.scripting?.executeScript) {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      func: startProofSnapSelectionOverlay,
-    });
-    return;
-  }
-
-  if (chrome.tabs?.executeScript) {
-    await new Promise<void>((resolve, reject) => {
-      chrome.tabs.executeScript(tabId, { code: getSelectionOverlayInjectionCode() }, () => {
-        const runtimeError = chrome.runtime.lastError;
-        if (runtimeError) {
-          reject(new Error(runtimeError.message || 'Legacy script injection failed'));
-          return;
-        }
-        resolve();
-      });
-    });
-    return;
-  }
-
-  throw new Error(
-    'Chrome scripting API is unavailable. Reload the extension after updating and make sure it is running as a Manifest V3 extension with the scripting permission.'
-  );
-}
-
 /**
  * Handle selection mode capture
  * Injects content script and waits for user selection
@@ -483,7 +451,10 @@ async function handleSelectionCapture(tab: chrome.tabs.Tab, fromPopup: boolean):
       logger.warn('Could not focus selection target before injection:', getErrorMessage(focusError));
     }
 
-    await injectSelectionOverlay(tab.id);
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: startProofSnapSelectionOverlay,
+    });
   } catch (error) {
     const errorMessage = getErrorMessage(error);
     logger.error('Failed to inject selection script:', errorMessage);

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -421,6 +421,38 @@ function startProofSnapSelectionOverlay(): void {
   }
 }
 
+function getSelectionOverlayInjectionCode(): string {
+  return `(${startProofSnapSelectionOverlay.toString()})();`;
+}
+
+async function injectSelectionOverlay(tabId: number): Promise<void> {
+  if (chrome.scripting?.executeScript) {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: startProofSnapSelectionOverlay,
+    });
+    return;
+  }
+
+  if (chrome.tabs?.executeScript) {
+    await new Promise<void>((resolve, reject) => {
+      chrome.tabs.executeScript(tabId, { code: getSelectionOverlayInjectionCode() }, () => {
+        const runtimeError = chrome.runtime.lastError;
+        if (runtimeError) {
+          reject(new Error(runtimeError.message || 'Legacy script injection failed'));
+          return;
+        }
+        resolve();
+      });
+    });
+    return;
+  }
+
+  throw new Error(
+    'Chrome scripting API is unavailable. Reload the extension after updating and make sure it is running as a Manifest V3 extension with the scripting permission.'
+  );
+}
+
 /**
  * Handle selection mode capture
  * Injects content script and waits for user selection
@@ -451,10 +483,7 @@ async function handleSelectionCapture(tab: chrome.tabs.Tab, fromPopup: boolean):
       logger.warn('Could not focus selection target before injection:', getErrorMessage(focusError));
     }
 
-    await chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      func: startProofSnapSelectionOverlay,
-    });
+    await injectSelectionOverlay(tab.id);
   } catch (error) {
     const errorMessage = getErrorMessage(error);
     logger.error('Failed to inject selection script:', errorMessage);

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -271,8 +271,12 @@ function PopupApp() {
 
   // Listen for upload progress updates
   useEffect(() => {
-    const handleMessage = async (message: any) => {
-      if (message.type === 'UPLOAD_PROGRESS') {
+    const handleMessage = (message: any) => {
+      if (message.type !== 'UPLOAD_PROGRESS') {
+        return false;
+      }
+
+      void (async () => {
         const payload = message.payload;
 
         // Reload assets to show updated progress
@@ -291,7 +295,9 @@ function PopupApp() {
             metadata: { nid: payload.nid },
           } as any);
         }
-      }
+      })();
+
+      return false;
     };
 
     chrome.runtime.onMessage.addListener(handleMessage);


### PR DESCRIPTION
## Summary

Fixes popup-initiated Snap captures saving without a watermark. The popup runtime listener now ignores unrelated messages synchronously so the offscreen document can respond to `ADD_WATERMARK` while the popup remains open.

## Changes

- Narrowed the popup `chrome.runtime.onMessage` handler to `UPLOAD_PROGRESS` only.
- Moved upload-progress async work into a fire-and-forget task so the listener does not return a Promise to the Chrome runtime.
- Kept selection overlay injection unchanged; no broad host permissions added.

## Verification

- `gh pr checks 84`: ci pass
- `npm run type-check`: pass
- `npm run lint`: 0 errors, existing warnings only
- `npm run build`: pass

---
Generated by Olga Shen with [Omni](https://omniai.one/)