### PR TITLE
[Omni] Refresh badge after deleting popup assets

### DIFF
--- a/.omni/e42f8a19-untitled/memory.md
+++ b/.omni/e42f8a19-untitled/memory.md
@@ -19,6 +19,7 @@
 
 - Selection capture is coordinated in `src/background/service-worker.ts`: popup sends `CAPTURE_SCREENSHOT`, service worker injects the selection overlay, then receives `SELECTION_COMPLETE` and crops via the offscreen document.
 - Popup runtime message listeners must ignore unrelated messages synchronously; an async listener can interfere with offscreen `ADD_WATERMARK` responses while the popup is open.
+- Extension badge count is maintained by background `updateExtensionBadge()` from IndexedDB asset count; popup-side deletes should send `REFRESH_BADGE`.
 
 ---
-_Last system refresh: 2026-05-06 07:09 UTC_
+_Last system refresh: 2026-05-06 07:28 UTC_

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -173,6 +173,17 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
         });
       return true;
 
+    case 'REFRESH_BADGE':
+      // Only allow from extension pages, not content scripts
+      if (sender.tab) {
+        sendResponse({ success: false, error: 'Unauthorized sender' });
+        return false;
+      }
+      updateExtensionBadge()
+        .then(() => sendResponse({ success: true }))
+        .catch((error) => sendResponse({ success: false, error: error.message }));
+      return true;
+
     default:
       logger.warn('Unknown message type:', message.type);
       sendResponse({ success: false, error: 'Unknown message type' });

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -195,6 +195,17 @@ function PopupApp() {
     }
   }
 
+  async function refreshExtensionBadge() {
+    try {
+      const response = await chrome.runtime.sendMessage({ type: 'REFRESH_BADGE' });
+      if (!response?.success) {
+        logger.warn('Failed to refresh badge:', response?.error || 'Unknown error');
+      }
+    } catch (error) {
+      logger.warn('Failed to refresh badge:', error);
+    }
+  }
+
   async function handleDeleteAsset(assetId: string) {
     if (!confirm('Are you sure you want to delete this screenshot?')) {
       return;
@@ -204,6 +215,7 @@ function PopupApp() {
       const updatedAssets = await indexedDBService.getAllAssets();
       setAssets(updatedAssets);
       setEditingAsset(null);
+      await refreshExtensionBadge();
     } catch (error) {
       logger.error('Failed to delete asset:', error);
       alert('Failed to delete screenshot');
@@ -257,6 +269,7 @@ function PopupApp() {
       try {
         const allAssets = await indexedDBService.getAllAssets();
         await Promise.all(allAssets.map((asset) => indexedDBService.deleteAsset(asset.id)));
+        await refreshExtensionBadge();
       } catch (error) {
         logger.error('Failed to clear IndexedDB assets on logout:', error);
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,7 +47,8 @@ export type MessageType =
   | 'ADD_WATERMARK'
   | 'START_GOOGLE_AUTH'
   | 'SELECTION_COMPLETE'
-  | 'CROP_IMAGE';
+  | 'CROP_IMAGE'
+  | 'REFRESH_BADGE';
 
 export interface ExtensionMessage<T = any> {
   type: MessageType;


### PR DESCRIPTION
## Summary
This PR ensures the extension badge stays in sync after popup assets are deleted. It adds a background message path for refreshing badge state and has the popup trigger it after a successful delete, preventing stale badge counts or indicators.

## Changes
- Add badge refresh handling in `src/background/service-worker.ts` for popup-initiated refresh requests.
- Update `src/popup/popup.tsx` to request a badge refresh after deleting popup assets.
- Extend shared message types in `src/types/index.ts` to include the new badge refresh message.

4 files changed, +28 additions, -2 deletions

<details>
<summary>File changes</summary>

```
.omni/e42f8a19-untitled/memory.md |  3 ++-
 src/background/service-worker.ts  | 11 +++++++++++
 src/popup/popup.tsx               | 13 +++++++++++++
 src/types/index.ts                |  3 ++-
```
</details>

---
Generated by Olga Shen with [Omni](https://omniai.one/)