### PR TITLE
[Omni] Verify release tags before pushing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -55,6 +56,14 @@ jobs:
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "old_version=$OLD_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Verify release tag is available
+        run: |
+          git fetch --tags origin
+          if git rev-parse -q --verify "refs/tags/v${{ steps.bump.outputs.new_version }}" >/dev/null; then
+            echo "Release tag v${{ steps.bump.outputs.new_version }} already exists. Choose a higher target_version or version_type."
+            exit 1
+          fi
+
       - name: Generate manifest.json from template
         run: node scripts/generate-manifest.js
         env:
@@ -81,8 +90,7 @@ jobs:
           git add manifest.template.json package.json package-lock.json
           git commit -m "chore: release version ${{ steps.bump.outputs.new_version }}"
           git tag -a "v${{ steps.bump.outputs.new_version }}" -m "Release version ${{ steps.bump.outputs.new_version }}"
-          git push origin main
-          git push origin "v${{ steps.bump.outputs.new_version }}"
+          git push --atomic origin HEAD:main "v${{ steps.bump.outputs.new_version }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.omni/e42f8a19-untitled/memory.md
+++ b/.omni/e42f8a19-untitled/memory.md
@@ -20,6 +20,7 @@
 - Selection capture is coordinated in `src/background/service-worker.ts`: popup sends `CAPTURE_SCREENSHOT`, service worker injects the selection overlay, then receives `SELECTION_COMPLETE` and crops via the offscreen document.
 - Popup runtime message listeners must ignore unrelated messages synchronously; an async listener can interfere with offscreen `ADD_WATERMARK` responses while the popup is open.
 - Extension badge count is maintained by background `updateExtensionBadge()` from IndexedDB asset count; popup-side deletes should send `REFRESH_BADGE`.
+- Release workflow must check tag availability before pushing and use atomic main+tag push to avoid partial release state.
 
 ---
-_Last system refresh: 2026-05-06 07:28 UTC_
+_Last system refresh: 2026-05-06 07:49 UTC_


### PR DESCRIPTION
## Summary
Update the release workflow to fetch full Git history and validate release tags before pushing changes. This prevents release runs from partially updating `main` when the target version tag already exists, keeping branch and tag pushes atomic and avoiding inconsistent release state.

## Changes
- Set `fetch-depth: 0` in `.github/workflows/release.yml` so the workflow can inspect existing tags.
- Add a pre-push check for the computed release tag before updating `main`.
- Keep the release push flow focused on preventing duplicate tags without broadening unrelated workflow behavior.

2 files changed, +12 additions, -3 deletions

<details>
<summary>File changes</summary>

```
.github/workflows/release.yml     | 12 ++++++++++--
 .omni/e42f8a19-untitled/memory.md |  3 ++-
```
</details>

---
Generated by Olga Shen with [Omni](https://omniai.one/)